### PR TITLE
Add custom cloudwatch metric, add local running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 ## Snyk Tag Monitor
 
-Snyk has a limit of 1000 unique key-value pairs that can be used as tags. This scheduled lambda checks the number of tags we are using once every two days, and sends an email to the security team if that number is higher than 900.
+Snyk allowed us a custom limit of 5000 unique key-value pairs that can be used as tags. This scheduled lambda checks the number
+of tags we are using once every two days, and sends an email to the security team if that number is higher than 4500. The
+number of tags is logged, and also registered as a cloudwatch datapoint. Cloudwatch will use the `stage` dimension `DEV` or
+`INFRA`, depending on whether the code was run locally or on AWS, respectively.
+
+### Running locally
+Before running the code locally you will need
+- Federated access to the security account, and that profile set to the default. (setting the `AWS_DEFAULT_PROFILE` environment
+variable is a quick way to do this)
+- A default region set.
+
+To run, execute the setup script (in `scripts/setup.sh`) to install all required dependencies in a virtual
+environment. Activate the environment by running `source .venv/bin/activate` from the root of the project, and finally, run the
+program using `python3 main.py`.

--- a/main.py
+++ b/main.py
@@ -3,6 +3,9 @@ import requests
 from requests import Response
 import boto3
 from botocore.config import Config
+import datetime
+
+app_name = 'snyk-tag-monitor'
 
 def get_secret_value_from_arn(arn_env_var, secret_client) -> str:
     arn_value: str | None = os.environ.get(arn_env_var, None)
@@ -38,7 +41,7 @@ def get_snyk_tags(snyk_group_id: str, snyk_api_key: str, page_number: int, tags:
     else:
         response_json = response.json()
         tags_on_this_page = response_json['tags']
-        print(f'page: {page_number}, tags: {len(tags_on_this_page)}')
+        print('{' + f'app: {app_name}, page: {page_number}, tags: {len(tags_on_this_page)}' + '}')
 
         if(len(tags_on_this_page) == page_size):
             next_page = page_number + 1
@@ -47,27 +50,44 @@ def get_snyk_tags(snyk_group_id: str, snyk_api_key: str, page_number: int, tags:
             return tags + tags_on_this_page
 
 def handler(event = None, context = None):
-    print("The snyk-tag-monitor is starting.")
+    print(f"The {app_name} is starting.")
 
     client_config = Config(
     region_name = 'eu-west-1',
     )
 
-    tag_warning_limit = 900
-    tag_hard_limit = 1000
+    tag_warning_limit = 4500
+    tag_hard_limit = 5000
     stage = os.environ.get("STAGE", "DEV")
-    parameter_store_client = client = boto3.client('ssm', config = client_config)
-    snyk_api_key = parameter_store_client.get_parameter(Name = f"/INFRA/security/snyk-tag-monitor/snyk-api-key", WithDecryption=True)['Parameter']['Value']
-    snyk_group_id = parameter_store_client.get_parameter(Name = f"/INFRA/security/snyk-tag-monitor/snyk-group-id")['Parameter']['Value']
+    parameter_store = boto3.client('ssm', config = client_config)
+    cloudwatch = boto3.client('cloudwatch', config = client_config)
+    snyk_api_key = parameter_store.get_parameter(Name = f"/INFRA/security/{app_name}/snyk-api-key", WithDecryption=True)['Parameter']['Value']
+    snyk_group_id = parameter_store.get_parameter(Name = f"/INFRA/security/{app_name}/snyk-group-id")['Parameter']['Value']
     sns_topic_arn: str = os.environ.get("SNS_TOPIC_ARN", None)
 
     all_tags = get_snyk_tags(snyk_group_id, snyk_api_key, 1)
     number_of_tags = len(all_tags)
+
+    metric_data = [
+        {
+            'MetricName': 'snykTagCount',
+            'Timestamp': datetime.datetime.now(),
+            'Dimensions': [
+               {
+                   'Name': 'Stage',
+                   'Value': stage
+               },
+           ],
+            'Value': number_of_tags,
+        },
+    ]
+
+    cloudwatch.put_metric_data(Namespace = app_name, MetricData = metric_data)
     if(number_of_tags > tag_warning_limit):
         msg = f'There are currently {number_of_tags} Snyk tags. Snyk has a limit of {tag_hard_limit} tags. Go do something about it...'
         send_notification(sns_topic_arn, msg, stage)
 
-    print("Done. The snyk-tag-monitor completed successfully.")
+    print(f"Done. The {app_name} completed successfully.")
 
 if __name__ == "__main__":
     handler()


### PR DESCRIPTION
## What does this change?

- This PR allows us to keep track of the tag number over time, by publishing a custom metric to cloudwatch. The `stage` dimension will change depending on whether the code was run locally, or on AWS Lambda.
- Tag limit has been updated from 1k to 5k
- It also adds a section to the readme with details of how to run the code locally.

## Why?

- We want a historical view of tag usage over time, to give us a better idea of the rate of change over time, and if we need to change the way we use tags to prevent us from regularly hitting the limit and needing to clear old tags out.
- Local execution instructions improve developer experience, reducing feedback loop times and preventing unnecessary deployments