### PR TITLE
clear out orphaned tags before counting. run every day

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 ## Snyk Tag Monitor
 
-Snyk allowed us a custom limit of 5000 unique key-value pairs that can be used as tags. This scheduled lambda checks the number
-of tags we are using once every two days, and sends an email to the security team if that number is higher than 4500. The
-number of tags is logged, and also registered as a cloudwatch datapoint. Cloudwatch will use the `stage` dimension `DEV` or
-`INFRA`, depending on whether the code was run locally or on AWS, respectively.
+Snyk allowed us a custom limit of 5000 unique key-value pairs that can be used as tags. This scheduled lambda first clears out
+any orphaned tags, then counts up the remaining tags in use on snyk projects. The lambda runs every day, and sends
+an email to the security team if that number is higher than 4500. The number of tags is logged, and also registered as a
+cloudwatch datapoint. Cloudwatch will use the `stage` dimension `DEV` or`INFRA`, depending on whether the code was run locally
+or on AWS, respectively.
 
 ### Running locally
 Before running the code locally you will need

--- a/aws_helpers.py
+++ b/aws_helpers.py
@@ -1,0 +1,56 @@
+import boto3
+from botocore.config import Config
+import os
+import datetime
+
+_stage = os.environ.get("STAGE", "DEV")
+
+_client_config = Config(
+region_name = 'eu-west-1',
+)
+
+def _send_tag_count_to_cloudwatch(number_of_tags: int, app_name: str):
+
+    cloudwatch = boto3.client('cloudwatch', config = _client_config)
+
+    metric_data = [
+        {
+            'MetricName': 'snykTagCount',
+            'Timestamp': datetime.datetime.now(),
+            'Dimensions': [
+            {
+                'Name': 'Stage',
+                'Value': _stage
+            },
+        ],
+            'Value': number_of_tags,
+        },
+    ]
+
+    cloudwatch.put_metric_data(Namespace = app_name, MetricData = metric_data)
+
+parameter_store = boto3.client('ssm', config = _client_config)
+
+
+def _send_notification(sns_topic_arn: str, message: str, stage: str):
+    if (stage == "INFRA"):
+        boto3.client('sns').publish(
+            TargetArn = sns_topic_arn,
+            Message = message,
+            Subject = "Approaching snyk tag limit - action required"
+        )
+    else:
+        print("Local environment detected. Not attempting to publish")
+
+def record_tag_count(number_of_tags: int, app_name: str):
+    sns_topic_arn: str = os.environ.get("SNS_TOPIC_ARN", None)
+
+    _send_tag_count_to_cloudwatch(number_of_tags, app_name)
+    print("sent tag count to cloudwatch")
+    tag_warning_limit = 4500
+    tag_hard_limit = 5000
+    
+    if(number_of_tags > tag_warning_limit):
+        msg = f'There are currently {number_of_tags} Snyk tags. Snyk has a limit of {tag_hard_limit} tags. Go do something about it...'
+        _send_notification(sns_topic_arn, msg, _stage)
+        print("sent sns notification")

--- a/cdk/lib/__snapshots__/snyk-tag-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/snyk-tag-monitor.test.ts.snap
@@ -349,9 +349,28 @@ exports[`The SnykTagMonitor stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "snyktagmonitorsnyktagmonitorrate2days0855530AE": {
+    "snyktagmonitorsnyktagmonitorrate1day0AllowEventRuleSnykTagMonitorsnyktagmonitorAE4097CFB7932521": {
       "Properties": {
-        "ScheduleExpression": "rate(2 days)",
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "snyktagmonitor01C2294D",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "snyktagmonitorsnyktagmonitorrate1day0D20FBF83",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "snyktagmonitorsnyktagmonitorrate1day0D20FBF83": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 day)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -366,25 +385,6 @@ exports[`The SnykTagMonitor stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::Events::Rule",
-    },
-    "snyktagmonitorsnyktagmonitorrate2days0AllowEventRuleSnykTagMonitorsnyktagmonitorAE4097CF9D0524BC": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "snyktagmonitor01C2294D",
-            "Arn",
-          ],
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "snyktagmonitorsnyktagmonitorrate2days0855530AE",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
     },
     "snyktagmonitortopicF2FA58D7": {
       "Properties": {

--- a/cdk/lib/snyk-tag-monitor.ts
+++ b/cdk/lib/snyk-tag-monitor.ts
@@ -6,7 +6,6 @@ import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
-import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 
@@ -22,7 +21,7 @@ export class SnykTagMonitor extends GuStack {
 		);
 
 		const lambdaProps: GuScheduledLambdaProps = {
-			rules: [{ schedule: Schedule.rate(Duration.days(2)) }],
+			rules: [{ schedule: Schedule.rate(Duration.days(1)) }],
 			monitoringConfiguration: {
 				toleratedErrorPercentage: 50,
 				snsTopicName: topic.topicName,

--- a/main.py
+++ b/main.py
@@ -1,93 +1,14 @@
-import os
-import requests
-from requests import Response
-import boto3
-from botocore.config import Config
-import datetime
+from aws_helpers import parameter_store, record_tag_count
+from snyk_helpers import delete_tags_and_count
 
 app_name = 'snyk-tag-monitor'
-
-def get_secret_value_from_arn(arn_env_var, secret_client) -> str:
-    arn_value: str | None = os.environ.get(arn_env_var, None)
-    secret_value = secret_client.get_secret_value(SecretId=arn_value)
-    return secret_value['SecretString']
-
-def send_notification(sns_topic_arn: str, message: str, stage: str):
-    if (stage == "INFRA"):
-        boto3.client('sns').publish(
-            TargetArn = sns_topic_arn,
-            Message = message,
-            Subject = "Approaching snyk tag limit - action required"
-        )
-    else:
-        print("Local environment detected. Not attempting to publish")
-
-def get_snyk_tag_page(snyk_group_id: str, snyk_api_key: str, page_number: int, page_size: int) -> Response:
-    snykurl: str = "https://api.snyk.io/api/v1/group/" + snyk_group_id + "/tags?perPage=" + str(page_size) + "&page=" + str(page_number)
-    headers: dict[str, str] = {
-        'Authorization': f'token {snyk_api_key}',
-        'Accept': 'application/json'
-    }
-    return requests.get(url=snykurl, headers=headers)
-
-def get_snyk_tags(snyk_group_id: str, snyk_api_key: str, page_number: int, tags: list =[]):
-    page_size: int = 1000
-    response: Response = get_snyk_tag_page(snyk_group_id, snyk_api_key, page_number, page_size)
-
-    if(response.status_code != 200):
-        print("Failed to make request to Snyk")
-        print(response.text)
-        raise Exception(f'{response.status_code} : {response.content}')
-    else:
-        response_json = response.json()
-        tags_on_this_page = response_json['tags']
-        print('{' + f'app: {app_name}, page: {page_number}, tags: {len(tags_on_this_page)}' + '}')
-
-        if(len(tags_on_this_page) == page_size):
-            next_page = page_number + 1
-            return tags + get_snyk_tags(snyk_group_id, snyk_api_key, next_page, tags_on_this_page)
-        else:
-            return tags + tags_on_this_page
+snyk_api_key = parameter_store.get_parameter(Name = f"/INFRA/security/{app_name}/snyk-api-key", WithDecryption=True)['Parameter']['Value']
+snyk_group_id = parameter_store.get_parameter(Name = f"/INFRA/security/{app_name}/snyk-group-id")['Parameter']['Value']
 
 def handler(event = None, context = None):
-    print(f"The {app_name} is starting.")
-
-    client_config = Config(
-    region_name = 'eu-west-1',
-    )
-
-    tag_warning_limit = 4500
-    tag_hard_limit = 5000
-    stage = os.environ.get("STAGE", "DEV")
-    parameter_store = boto3.client('ssm', config = client_config)
-    cloudwatch = boto3.client('cloudwatch', config = client_config)
-    snyk_api_key = parameter_store.get_parameter(Name = f"/INFRA/security/{app_name}/snyk-api-key", WithDecryption=True)['Parameter']['Value']
-    snyk_group_id = parameter_store.get_parameter(Name = f"/INFRA/security/{app_name}/snyk-group-id")['Parameter']['Value']
-    sns_topic_arn: str = os.environ.get("SNS_TOPIC_ARN", None)
-
-    all_tags = get_snyk_tags(snyk_group_id, snyk_api_key, 1)
-    number_of_tags = len(all_tags)
-
-    metric_data = [
-        {
-            'MetricName': 'snykTagCount',
-            'Timestamp': datetime.datetime.now(),
-            'Dimensions': [
-               {
-                   'Name': 'Stage',
-                   'Value': stage
-               },
-           ],
-            'Value': number_of_tags,
-        },
-    ]
-
-    cloudwatch.put_metric_data(Namespace = app_name, MetricData = metric_data)
-    if(number_of_tags > tag_warning_limit):
-        msg = f'There are currently {number_of_tags} Snyk tags. Snyk has a limit of {tag_hard_limit} tags. Go do something about it...'
-        send_notification(sns_topic_arn, msg, stage)
-
-    print(f"Done. The {app_name} completed successfully.")
+    tag_count: int = delete_tags_and_count(snyk_api_key, snyk_group_id)
+    record_tag_count(tag_count, app_name)
 
 if __name__ == "__main__":
     handler()
+    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto3==1.26.9
 requests==2.28.1
+pysnyk==0.9.3

--- a/snyk_helpers.py
+++ b/snyk_helpers.py
@@ -1,0 +1,72 @@
+from requests import Response
+import requests
+from snyk import SnykClient
+
+def _get_snyk_tag_page(snyk_group_id: str, snyk_api_key: str, page_number: int, page_size: int) -> Response:
+    snykurl: str = "https://api.snyk.io/api/v1/group/" + snyk_group_id + "/tags?perPage=" + str(page_size) + "&page=" + str(page_number)
+    headers: dict[str, str] = {
+        'Authorization': f'token {snyk_api_key}',
+        'Accept': 'application/json'
+    }
+    return requests.get(url=snykurl, headers=headers)
+
+def _get_snyk_tags(snyk_group_id: str, snyk_api_key: str, page_number: int, tags: list =[]):
+    page_size: int = 1000
+    response: Response = _get_snyk_tag_page(snyk_group_id, snyk_api_key, page_number, page_size)
+
+    if(response.status_code != 200):
+        print(f'Failed to get page {page_number} of tags from snyk')
+        print(f'{response.status_code} : {response.content}')
+        raise Exception(f'{response.status_code} : {response.content}')
+    else:
+        response_json = response.json()
+        tags_on_this_page = response_json['tags']
+        print(f'page: {page_number}, tags: {len(tags_on_this_page)}')
+
+        if(len(tags_on_this_page) == page_size):
+            next_page = page_number + 1
+            return tags + _get_snyk_tags(snyk_group_id, snyk_api_key, next_page, tags_on_this_page)
+        else:
+            return tags + tags_on_this_page
+
+def _delete_tag(tag_dict, group_id, snyk_key):
+
+  delete_tag_url = "https://api.snyk.io/api/v1/group/" + group_id + "/tags/delete"
+  json_body = {"key": tag_dict['key'], "value": tag_dict['value'], "force": False}
+
+  response = requests.post(url = delete_tag_url, headers={'Authorization': 'token ' + snyk_key }, json=json_body)
+  if response.status_code != 200:
+    print("Failed to delete tag")
+    print(f'code : {response.status_code}, content: {response.content}')
+
+def _get_owned_tags(snyk_key):
+
+    def deduplicate_dict_list(dict_list):
+        return [dict(t) for t in {tuple(d.items()) for d in dict_list}]
+    
+    client: SnykClient = SnykClient(snyk_key)
+    projects: list = client.projects.all()
+    nested_tag_list = [project.tags.all() for project in projects]
+    flat_list = [item for sublist in nested_tag_list for item in sublist]
+    return deduplicate_dict_list(flat_list)
+
+def delete_tags_and_count(snyk_api_key: str, snyk_group_id: str) -> int:
+
+    owned_tags = _get_owned_tags(snyk_api_key)
+    initial_tag_list = _get_snyk_tags(snyk_group_id, snyk_api_key, 1)
+    print(f"starting tags: {len(initial_tag_list)}")
+
+    orphaned_tags = list(filter(lambda x: x not in owned_tags, initial_tag_list))
+    orphaned_tag_count = len(orphaned_tags)
+    print(f"orphaned tags: {orphaned_tag_count}")
+
+    for tag in orphaned_tags:
+        _delete_tag(tag, snyk_group_id, snyk_api_key)
+    
+    final_tag_list = _get_snyk_tags(snyk_group_id, snyk_api_key, 1)
+
+    number_of_tags = len(final_tag_list)
+    deleted_tag_count = len(initial_tag_list) - len(final_tag_list)
+    print(f'deleted tags: {deleted_tag_count}')
+
+    return number_of_tags


### PR DESCRIPTION
## What does this change?

We wanted to create an automated process to clear out old tags. Most of the logic needed to do this already exists in this lambda, so I've extended it to clear these tags out before running a count. I have

-  Introduced the `delete_tags_and_count` method in `snyk_helpers`, which returns a final tag count.
-  The tag count is passed to `record_tag_count`, which contains most of what used to be the handler method.
- Most of the other changes are just moving the helper methods into modules.
- Made relevant module methods private by prepending them with an underscore
- Made a cdk change to run once a day to support a cloudwatch alarm, where max evaluation periods are 1 day
