### PR TITLE
add alarm to lambda rather than rely on sns

### DIFF
--- a/cdk/lib/__snapshots__/snyk-tag-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/snyk-tag-monitor.test.ts.snap
@@ -72,7 +72,7 @@ exports[`The SnykTagMonitor stack matches the snapshot 1`] = `
             "Value": "TEST",
           },
         ],
-        "Timeout": 30,
+        "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
     },

--- a/cdk/lib/__snapshots__/snyk-tag-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/snyk-tag-monitor.test.ts.snap
@@ -4,6 +4,7 @@ exports[`The SnykTagMonitor stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
+      "GuAlarm",
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
@@ -337,6 +338,11 @@ exports[`The SnykTagMonitor stack matches the snapshot 1`] = `
                 "Ref": "snyktagmonitortopicF2FA58D7",
               },
             },
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -348,6 +354,49 @@ exports[`The SnykTagMonitor stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "snyktagmonitoralarm178C7D05": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "snyktagmonitortopicF2FA58D7",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "stage",
+            "Value": "TEST",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "snykTagCount",
+        "Namespace": "snyk-tag-monitor",
+        "Period": 86400,
+        "Statistic": "Minimum",
+        "Threshold": 4500,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "snyktagmonitorsnyktagmonitorrate1day0AllowEventRuleSnykTagMonitorsnyktagmonitorAE4097CFB7932521": {
       "Properties": {

--- a/cdk/lib/snyk-tag-monitor.ts
+++ b/cdk/lib/snyk-tag-monitor.ts
@@ -59,7 +59,7 @@ export class SnykTagMonitor extends GuStack {
 			environment: {
 				SNS_TOPIC_ARN: topic.topicArn,
 			},
-			timeout: Duration.minutes(15)
+			timeout: Duration.minutes(5)
 		};
 
 		const lambda = new GuScheduledLambda(this, app, lambdaProps);

--- a/cdk/lib/snyk-tag-monitor.ts
+++ b/cdk/lib/snyk-tag-monitor.ts
@@ -59,6 +59,7 @@ export class SnykTagMonitor extends GuStack {
 			environment: {
 				SNS_TOPIC_ARN: topic.topicArn,
 			},
+			timeout: Duration.minutes(15)
 		};
 
 		const lambda = new GuScheduledLambda(this, app, lambdaProps);

--- a/cdk/lib/snyk-tag-monitor.ts
+++ b/cdk/lib/snyk-tag-monitor.ts
@@ -1,10 +1,15 @@
+import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
+import type { GuAlarmProps } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { GuScheduledLambdaProps } from '@guardian/cdk/lib/patterns';
 import { GuScheduledLambda } from '@guardian/cdk/lib/patterns';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
+import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
+import type { MetricProps } from 'aws-cdk-lib/aws-cloudwatch';
 import { Schedule } from 'aws-cdk-lib/aws-events';
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
@@ -19,6 +24,27 @@ export class SnykTagMonitor extends GuStack {
 		topic.addSubscription(
 			new EmailSubscription('devx.security@guardian.co.uk'),
 		);
+
+        const metricProps: MetricProps = {
+            namespace: 'snyk-tag-monitor',
+            metricName: 'snykTagCount',
+            dimensionsMap: {
+                'stage': this.stage
+            },
+            period: Duration.days(1),
+            statistic: "Minimum"
+        }
+        const tagMetric = new Metric(metricProps)
+
+        const tagAlarmProps: GuAlarmProps = {
+            comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+            threshold: 4500,
+            evaluationPeriods: 1,
+            snsTopicName: topic.topicName,
+            metric: tagMetric,
+            app: app,
+            }
+        const tagAlarm = new GuAlarm(this, `${app}-alarm`, tagAlarmProps)
 
 		const lambdaProps: GuScheduledLambdaProps = {
 			rules: [{ schedule: Schedule.rate(Duration.days(1)) }],
@@ -36,8 +62,9 @@ export class SnykTagMonitor extends GuStack {
 		};
 
 		const lambda = new GuScheduledLambda(this, app, lambdaProps);
-
 		topic.grantPublish(lambda);
+        const policyStatement = new PolicyStatement({actions: ['cloudwatch:PutMetricData'], resources: ['*']})
+        lambda.addToRolePolicy(policyStatement)
 		
 	}
 }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -24,8 +24,8 @@ pip3 install -r "$ROOT_DIR/requirements.txt"
   MAJOR_PYTHON_VERSION="3.9"
   PACKAGE_DIR="${ROOT_DIR}/.venv/lib/python${MAJOR_PYTHON_VERSION}/site-packages"
   ZIP_FILE="${APP_NAME}.zip"
-
-  cp "${ROOT_DIR}/main.py" "${PACKAGE_DIR}"
-  cd "${PACKAGE_DIR}"
+  cd "$ROOT_DIR"
+  cp ./*.py "${PACKAGE_DIR}"
+  cd "$PACKAGE_DIR"
   zip -FSr "${ROOT_DIR}/${ZIP_FILE}" .
 )

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -24,8 +24,8 @@ pip3 install -r "$ROOT_DIR/requirements.txt"
   MAJOR_PYTHON_VERSION="3.9"
   PACKAGE_DIR="${ROOT_DIR}/.venv/lib/python${MAJOR_PYTHON_VERSION}/site-packages"
   ZIP_FILE="${APP_NAME}.zip"
-  cd "$ROOT_DIR"
-  cp ./*.py "${PACKAGE_DIR}"
-  cd "$PACKAGE_DIR"
+
+  cp "${ROOT_DIR}/main.py" "${PACKAGE_DIR}"
+  cd "${PACKAGE_DIR}"
   zip -FSr "${ROOT_DIR}/${ZIP_FILE}" .
 )


### PR DESCRIPTION
## What does this change?

Alarm that goes off if the tag count is >4500. Intended to replace the sns message, which will be removed in a separate PR
