### PR TITLE
make it clearer which errors are nonfatal

### DIFF
--- a/snyk_helpers.py
+++ b/snyk_helpers.py
@@ -15,7 +15,7 @@ def _get_snyk_tags(snyk_group_id: str, snyk_api_key: str, page_number: int, tags
     response: Response = _get_snyk_tag_page(snyk_group_id, snyk_api_key, page_number, page_size)
 
     if(response.status_code != 200):
-        print(f'Failed to get page {page_number} of tags from snyk')
+        print(f'error: failed to get page {page_number} of tags from snyk')
         print(f'{response.status_code} : {response.content}')
         raise Exception(f'{response.status_code} : {response.content}')
     else:
@@ -36,7 +36,7 @@ def _delete_tag(tag_dict, group_id, snyk_key):
 
   response = requests.post(url = delete_tag_url, headers={'Authorization': 'token ' + snyk_key }, json=json_body)
   if response.status_code != 200:
-    print("Failed to delete tag")
+    print(f'warning: failed to delete tag, tag: {str(tag_dict)}')
     print(f'code : {response.status_code}, content: {response.content}')
 
 def _get_owned_tags(snyk_key):


### PR DESCRIPTION
## What does this change?

adding some severity context to logs. logs failed tags

## Why?

previously a failure to delete a tag looked like it was causing a fatal error, but this is actually a safe operation - the lambda is able to continue if the call fails. this context makes that clearer

logging the tag for debugging purposes