### PR TITLE
Rename workflow for clarity

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 # Find full documentation here https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
-name: CI
+name: Lint
 
 on:
   pull_request:


### PR DESCRIPTION
## What does this change?

Rename the lint workflow for clarity.

## Why?

The name collides with the existing CI job, so it's confusing!