### PR TITLE
Lambda automatically retries

### DIFF
--- a/cdk/lib/__snapshots__/snyk-tag-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/snyk-tag-monitor.test.ts.snap
@@ -190,6 +190,16 @@ exports[`The SnykTagMonitor stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "snyktagmonitorEventInvokeConfig5F4D7B41": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "snyktagmonitor01C2294D",
+        },
+        "MaximumRetryAttempts": 1,
+        "Qualifier": "$LATEST",
+      },
+      "Type": "AWS::Lambda::EventInvokeConfig",
+    },
     "snyktagmonitorServiceRole8EBA8B3B": {
       "Properties": {
         "AssumeRolePolicyDocument": {

--- a/cdk/lib/snyk-tag-monitor.ts
+++ b/cdk/lib/snyk-tag-monitor.ts
@@ -59,7 +59,8 @@ export class SnykTagMonitor extends GuStack {
 			environment: {
 				SNS_TOPIC_ARN: topic.topicArn,
 			},
-			timeout: Duration.minutes(5)
+			timeout: Duration.minutes(5),
+			retryAttempts: 1
 		};
 
 		const lambda = new GuScheduledLambda(this, app, lambdaProps);


### PR DESCRIPTION
## What does this change?

If the lambda fails first time, it will try once more before erroring

## Why?
About once a week, this lambda fails, usually due to errors from snyk's API. Every time this happens, it is resolvable by running the lambda again. This PR automates that rerun