### PR TITLE
Upgrade pysnyk to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3==1.26.9
 requests==2.28.1
-pysnyk==0.9.3
+pysnyk==0.9.5


### PR DESCRIPTION
Co-authored-by: Natasha <NovemberTang@users.noreply.github.com>

## What does this change?
Upgrades `pysnyk` from v.0.9.3 -> v0.9.5 (latest), which fixes the issue of the last few days where the tag monitor was erroring.