### PR TITLE
specify origin of message

### DIFF
--- a/src/aws_helpers.py
+++ b/src/aws_helpers.py
@@ -57,6 +57,7 @@ def record_tag_count(number_of_tags: int, app_name: str):
         msg = \
             f'There are currently {number_of_tags} Snyk tags.' + \
             f'Snyk has a limit of {tag_hard_limit} tags. ' + \
-            'Go do something about it...'
+            'Go do something about it...\n' + \
+            'This message is from the snyk-tag-monitor'
         _send_notification(sns_topic_arn, msg, _stage)
         print("sent sns notification")


### PR DESCRIPTION
## What does this change?

The notification gives the recipient an indication of its origin

## Why?

It's useful for developers to know the origin of an alert, especially an infrequent one, as this knowledge may be lost over time.