### PR TITLE
Bump python dependencies, raise PRs monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,12 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
## What does this change?

1. Dependabot will update python dependencies
2. Version bumps will happen once a month

## Why?

1. The app is written in python, this is probably the most important code to have covered.
2. Constant dependency update PRs create a lot of noise, and mean we spend more time on version bumps, and less time on securing the department. Let's free up some time. If there are serious vulnerabilities that show up between dependabot PRs, we can patch them manually, or dependabot will raise a PR in the interim.