### PR TITLE
Bump `actions-riff-raff` to V4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,12 @@ jobs:
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
-      # required by aws-actions/configure-aws-credentials
+      # required by guardian/actions-riff-raff
       id-token: write
       contents: read
       pull-requests: write # required by guardian/actions-riff-raff
     steps:
       - uses: actions/checkout@v4
-
-      # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
-      # See https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -46,9 +39,10 @@ jobs:
         run: ./scripts/ci.sh
 
       - name: Upload to riff-raff
-        uses: guardian/actions-riff-raff@v3
+        uses: guardian/actions-riff-raff@v4
         with:
           app: snyk-tag-monitor
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           commentingStage: INFRA
           projectName: security::snyk-tag-monitor


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrade [guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff) to [v4](https://github.com/guardian/actions-riff-raff/releases/tag/v4).

## Why?

This allows us to remove the [aws-configure-credentials](https://github.com/aws-actions/configure-aws-credentials) step from the earlier part of the workflow.
See [`actions-riff-raff` change](https://github.com/guardian/actions-riff-raff/pull/108) for details.
