### PR TITLE
Run snyk tag monitor weekly

### DIFF
--- a/cdk/lib/__snapshots__/snyk-tag-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/snyk-tag-monitor.test.ts.snap
@@ -408,28 +408,9 @@ exports[`The SnykTagMonitor stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "snyktagmonitorsnyktagmonitorrate1day0AllowEventRuleSnykTagMonitorsnyktagmonitorAE4097CFB7932521": {
+    "snyktagmonitorsnyktagmonitorrate7days06190F24C": {
       "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "snyktagmonitor01C2294D",
-            "Arn",
-          ],
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "snyktagmonitorsnyktagmonitorrate1day0D20FBF83",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "snyktagmonitorsnyktagmonitorrate1day0D20FBF83": {
-      "Properties": {
-        "ScheduleExpression": "rate(1 day)",
+        "ScheduleExpression": "rate(7 days)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -444,6 +425,25 @@ exports[`The SnykTagMonitor stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::Events::Rule",
+    },
+    "snyktagmonitorsnyktagmonitorrate7days0AllowEventRuleSnykTagMonitorsnyktagmonitorAE4097CF885D65C7": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "snyktagmonitor01C2294D",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "snyktagmonitorsnyktagmonitorrate7days06190F24C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "snyktagmonitortopicF2FA58D7": {
       "Properties": {

--- a/cdk/lib/snyk-tag-monitor.ts
+++ b/cdk/lib/snyk-tag-monitor.ts
@@ -25,26 +25,26 @@ export class SnykTagMonitor extends GuStack {
 			new EmailSubscription('devx.security@guardian.co.uk'),
 		);
 
-        const metricProps: MetricProps = {
-            namespace: 'snyk-tag-monitor',
-            metricName: 'snykTagCount',
-            dimensionsMap: {
-                'stage': this.stage
-            },
-            period: Duration.days(1),
-            statistic: "Minimum"
-        }
-        const tagMetric = new Metric(metricProps)
+		const metricProps: MetricProps = {
+			namespace: 'snyk-tag-monitor',
+			metricName: 'snykTagCount',
+			dimensionsMap: {
+				stage: this.stage,
+			},
+			period: Duration.days(1),
+			statistic: 'Minimum',
+		};
+		const tagMetric = new Metric(metricProps);
 
-        const tagAlarmProps: GuAlarmProps = {
-            comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
-            threshold: 4500,
-            evaluationPeriods: 1,
-            snsTopicName: topic.topicName,
-            metric: tagMetric,
-            app: app,
-            }
-        const tagAlarm = new GuAlarm(this, `${app}-alarm`, tagAlarmProps)
+		const tagAlarmProps: GuAlarmProps = {
+			comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+			threshold: 4500,
+			evaluationPeriods: 1,
+			snsTopicName: topic.topicName,
+			metric: tagMetric,
+			app: app,
+		};
+		const tagAlarm = new GuAlarm(this, `${app}-alarm`, tagAlarmProps);
 
 		const lambdaProps: GuScheduledLambdaProps = {
 			rules: [{ schedule: Schedule.rate(Duration.days(7)) }],
@@ -60,13 +60,15 @@ export class SnykTagMonitor extends GuStack {
 				SNS_TOPIC_ARN: topic.topicArn,
 			},
 			timeout: Duration.minutes(5),
-			retryAttempts: 1
+			retryAttempts: 1,
 		};
 
 		const lambda = new GuScheduledLambda(this, app, lambdaProps);
 		topic.grantPublish(lambda);
-        const policyStatement = new PolicyStatement({actions: ['cloudwatch:PutMetricData'], resources: ['*']})
-        lambda.addToRolePolicy(policyStatement)
-		
+		const policyStatement = new PolicyStatement({
+			actions: ['cloudwatch:PutMetricData'],
+			resources: ['*'],
+		});
+		lambda.addToRolePolicy(policyStatement);
 	}
 }

--- a/cdk/lib/snyk-tag-monitor.ts
+++ b/cdk/lib/snyk-tag-monitor.ts
@@ -47,7 +47,7 @@ export class SnykTagMonitor extends GuStack {
         const tagAlarm = new GuAlarm(this, `${app}-alarm`, tagAlarmProps)
 
 		const lambdaProps: GuScheduledLambdaProps = {
-			rules: [{ schedule: Schedule.rate(Duration.days(1)) }],
+			rules: [{ schedule: Schedule.rate(Duration.days(7)) }],
 			monitoringConfiguration: {
 				toleratedErrorPercentage: 50,
 				snsTopicName: topic.topicName,


### PR DESCRIPTION
## What does this change?

Run the lambda once a week instead of daily

## Why?

The lambda doesn't seem to be clearing nearly as many tags out as it usually does, so lets knock the frequency down while we investigate
